### PR TITLE
A couple of improvements and hyphens to de_DE.properties

### DIFF
--- a/assets/bigreactors/languages/de_DE.properties
+++ b/assets/bigreactors/languages/de_DE.properties
@@ -9,7 +9,7 @@ tile.yelloriumFuelRod.0.name=Yelloriumbrennstab
 tile.blockReactorControlRod.name=Reaktorsteuerstab
 tile.blockReactorGlass.name=Reaktorglas
 tile.blockReactorRedstonePort.name=Reaktor-Redstoneanschluss
-tile.blockReactorPart.0.name=Reaktorgehäuse
+tile.blockReactorPart.0.name=Reaktorgeh\u00e4use
 tile.blockReactorPart.1.name=Reaktorsteuerung
 tile.blockReactorPart.2.name=Reaktorstromanschluss
 tile.blockReactorPart.3.name=Reaktorzugang
@@ -27,12 +27,12 @@ item.dustYellorium.name=Yelloriumstaub
 item.dustCyanite.name=Cyanitstaub
 item.dustBlutonium.name=Blutoniumstaub
 item.dustGraphite.name=Graphitstaub
-item.bucket.cyanite.name=Eimer mit flüssigem Cyanit
-item.bucket.yellorium.name=Eimer mit flüssigem Yellorium
+item.bucket.cyanite.name=Eimer mit fl\u00fcssigem Cyanit
+item.bucket.yellorium.name=Eimer mit fl\u00fcssigem Yellorium
 
 # Fluids
 fluid.tile.water=Wasser
 fluid.tile.lava=Lava
-fluid.tile.yellorium=Flüssiges Yellorium
-fluid.tile.cyanite=Flüssiges Cyanit
-fluid.tile.blutonium=Flüssiges Blutonium
+fluid.tile.yellorium=Fl\u00fcssiges Yellorium
+fluid.tile.cyanite=Fl\u00fcssiges Cyanit
+fluid.tile.blutonium=Fl\u00fcssiges Blutonium


### PR DESCRIPTION
Now it is encoded correctly, also German language uses a lot of hyphens. I translated the "Ingot". And you do not usually translate the Mod's name (Creative tab)
