### PR TITLE
Control rod fertility fix

### DIFF
--- a/erogenousbeef/bigreactors/common/multiblock/tileentity/TileEntityReactorFuelRod.java
+++ b/erogenousbeef/bigreactors/common/multiblock/tileentity/TileEntityReactorFuelRod.java
@@ -51,13 +51,13 @@ public class TileEntityReactorFuelRod extends TileEntityReactorPartBase implemen
 		// Some fuels are better at absorbing radiation than others
 		float scaledAbsorption = Math.min(1f, baseAbsorption * getFuelAbsorptionCoefficient());
 
-                // Control rods increase total neutron absorption, but decrease the total neutrons which fertilize the fuel
-                // Absorb up to 50% better with control rods inserted.
-                controlRodBonus = (1f - scaledAbsorption) * controlRodInsertion * 0.5f;
+		// Control rods increase total neutron absorption, but decrease the total neutrons which fertilize the fuel
+		// Absorb up to 50% better with control rods inserted.
+		controlRodBonus = (1f - scaledAbsorption) * controlRodInsertion * 0.5f;
 		controlRodPenalty = scaledAbsorption * controlRodInsertion * 0.5f;
 		
 		float radiationAbsorbed = (scaledAbsorption + controlRodBonus) * radiation.intensity;
-                float fertilityAbsorbed = (scaledAbsorption - controlRodPenalty) * radiation.intensity;
+		float fertilityAbsorbed = (scaledAbsorption - controlRodPenalty) * radiation.intensity;
 		
 		float fuelModerationFactor = getFuelModerationFactor();
 		fuelModerationFactor += fuelModerationFactor * controlRodInsertion + controlRodInsertion; // Full insertion doubles the moderation factor of the fuel as well as adding its own level


### PR DESCRIPTION
I'd like to propose a fundamental behavior change based on some phenomena I noticed in version 0.2 (the behavior should still be present in 0.3).

Currently, the fertility rate of fuel rods _increases_ with higher control rod insertion. While the immediate emission rate is decreased, the future rate is actually increased due to increased fertility. In 0.2, I was able to create a reactor that was stable (as in it maintained a certain power/heat/radiation level) at control rod insertion of 10-20%. Once the control rod insertion level got higher than 30%, the increased absorption rate actually caused the overall 'k' value to become higher than 1 -- meaning that the reactor would emit MORE radiation in the future that it did in each generation. The control rod insertion only served to increase the 'doubling time', but did not actually reduce the final result.

This overall situation meant that the reactor was subcritical with the control rods out, but putting the control rods in made the reactor critical. I think that this is nonintuitive behavior that is actually not very good for gameplay -- If you try to use the control rods in reverse to manage the reactor, you end up spiking the radioactivity whenever you try to "reduce" the criticality which spikes the temperature and kills all efficiency.

I propose that instead the control rods should increase the _absorption_ of neutrons, but not the _fertility_ of the rods. So inserting the control rods all the way should cause most of the neutrons to be absorbed, but not into the fuel -- they go into the control rod and produce heat. Removing the control rods reduces the overall number absorbed, but the amount that actually reach the fuel increases.

This patch implements the proposed change. The overall relationship between control rod insertion level and neutron absorption remains the same, but now the fertility absorption instead follows the scheme:

```
data.fuelAbsorbedRadiation += scaledAbsorption * (1.0f - controlRodInsertion * 0.5f) * radiation.intensity;
```

I have left the value `data.fuelRfChange` unchanged.

You will probably need to rebalance certain other features to accommodate these changes (they reduce the power of reactors using control rods at >0%), but I think it would improve the mod overall.
