### PR TITLE
Changes metadata range in getIcon from 0-5 to 0-4

### DIFF
--- a/src/main/java/erogenousbeef/bigreactors/common/block/BlockBRMetal.java
+++ b/src/main/java/erogenousbeef/bigreactors/common/block/BlockBRMetal.java
@@ -37,7 +37,7 @@ public class BlockBRMetal extends Block {
 	@Override
 	public IIcon getIcon(int side, int metadata)
 	{
-		metadata = Math.max(0, Math.min(NUM_BLOCKS, metadata));
+		metadata = Math.max(0, Math.min(NUM_BLOCKS-1, metadata));
 		return _icons[metadata];
 	}
 	


### PR DESCRIPTION
getIcon throws an exception if metadata => 5. This alters getIcon so that _icons[metadata] won't cause a crash if the incoming metadata is 5 or greater.