### PR TITLE
Add 'liquidhelium' to the reactor's registered fluids.

### DIFF
--- a/src/main/java/erogenousbeef/bigreactors/common/BigReactors.java
+++ b/src/main/java/erogenousbeef/bigreactors/common/BigReactors.java
@@ -867,6 +867,7 @@ public class BigReactors {
 		ReactorInterior.registerFluid("pyrotheum",	0.66f, 0.90f, 1.00f, IHeatEntity.conductivityIron);
 		
 		ReactorInterior.registerFluid("life essence", 0.70f, 0.55f, 1.75f, IHeatEntity.conductivityGold); // From Blood Magic
+		ReactorInterior.registerFluid("liquidhelium",	0.72f, 0.98f, 1.95f, IHeatEntity.conductivityDiamond); // NuclearCraft
 
 		if(enableComedy) {
 			ReactorInterior.registerBlock("blockMeat", 	0.50f, 0.33f, 1.33f, IHeatEntity.conductivityStone);


### PR DESCRIPTION
Add 'liquidhelium' to the list of fluids that can be used in the reactor - it is, naturally, incredibly cold, so absorbs heat well, but does not moderate radiation as well. It is the ideal coolant (IRL), if ever there was one.
