### PR TITLE
Fix MultiBlock Reactor to avoid class-cast exception

### DIFF
--- a/src/main/java/erogenousbeef/bigreactors/common/multiblock/MultiblockReactor.java
+++ b/src/main/java/erogenousbeef/bigreactors/common/multiblock/MultiblockReactor.java
@@ -293,7 +293,7 @@ public class MultiblockReactor extends RectangularMultiblockControllerBase imple
 			//Avoid possible class-casting exception for control rod by testing the TileEntity first
 			if(proposedRod instanceof TileEntityReactorControlRod) {
 				//Reassign entity if it does cast properly
-				sourceControlRod = proposedRod;
+				sourceControlRod = (TileEntityReactorControlRod) proposedRod;
 				//Delete reference to control rod TileEntity
 				proposedRod = null;
 			}

--- a/src/main/java/erogenousbeef/bigreactors/common/multiblock/MultiblockReactor.java
+++ b/src/main/java/erogenousbeef/bigreactors/common/multiblock/MultiblockReactor.java
@@ -288,7 +288,15 @@ public class MultiblockReactor extends RectangularMultiblockControllerBase imple
 
 			// Radiate from that control rod
 			TileEntityReactorFuelRod source  = currentFuelRod.next();
-			TileEntityReactorControlRod sourceControlRod = (TileEntityReactorControlRod)worldObj.getTileEntity(source.xCoord, getMaximumCoord().y, source.zCoord);
+			TileEntityReactorControlRod sourceControlRod  = null;
+			TileEntity proposedRod = worldObj.getTileEntity(source.xCoord, getMaximumCoord().y, source.zCoord);
+			//Avoid possible class-casting exception for control rod by testing the TileEntity first
+			if(proposedRod instanceof TileEntityReactorControlRod) {
+				//Reassign entity if it does cast properly
+				sourceControlRod = proposedRod;
+				//Delete reference to control rod TileEntity
+				proposedRod = null;
+			}
 			if(sourceControlRod != null)
 			{
 				RadiationData radData = radiationHelper.radiate(worldObj, fuelContainer, source, sourceControlRod, getFuelHeat(), getReactorHeat(), attachedControlRods.size());


### PR DESCRIPTION
Prevents the casting of the entity that **should** be the control rod directly to the control rod class.
Instead tests if the tile entity is **actually** a control rod first, then assigns.
