### PR TITLE
fixed possible crash 

### DIFF
--- a/src/main/java/erogenousbeef/bigreactors/common/multiblock/MultiblockReactor.java
+++ b/src/main/java/erogenousbeef/bigreactors/common/multiblock/MultiblockReactor.java
@@ -1,11 +1,9 @@
 package erogenousbeef.bigreactors.common.multiblock;
 
 import io.netty.buffer.ByteBuf;
-
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.player.EntityPlayer;
@@ -288,11 +286,10 @@ public class MultiblockReactor extends RectangularMultiblockControllerBase imple
 
 			// Radiate from that control rod
 			TileEntityReactorFuelRod source  = currentFuelRod.next();
-			TileEntityReactorControlRod sourceControlRod = (TileEntityReactorControlRod)worldObj.getTileEntity(source.xCoord, getMaximumCoord().y, source.zCoord);
-			if(sourceControlRod != null)
-			{
+			TileEntity tileEntity = worldObj.getTileEntity(source.xCoord, getMaximumCoord().y, source.zCoord);
+			if (tileEntity instanceof TileEntityReactorControlRod) {
+				TileEntityReactorControlRod sourceControlRod = (TileEntityReactorControlRod) tileEntity;
 				RadiationData radData = radiationHelper.radiate(worldObj, fuelContainer, source, sourceControlRod, getFuelHeat(), getReactorHeat(), attachedControlRods.size());
-
 				// Assimilate results of radiation
 				if(radData != null) {
 					addFuelHeat(radData.getFuelHeatChange(attachedFuelRods.size()));

--- a/src/main/java/erogenousbeef/bigreactors/common/multiblock/MultiblockReactor.java
+++ b/src/main/java/erogenousbeef/bigreactors/common/multiblock/MultiblockReactor.java
@@ -283,18 +283,19 @@ public class MultiblockReactor extends RectangularMultiblockControllerBase imple
 			if(!currentFuelRod.hasNext()) {
 				currentFuelRod = attachedFuelRods.iterator();
 			}
-
-			// Radiate from that control rod
-			TileEntityReactorFuelRod source  = currentFuelRod.next();
-			TileEntity tileEntity = worldObj.getTileEntity(source.xCoord, getMaximumCoord().y, source.zCoord);
-			if (tileEntity instanceof TileEntityReactorControlRod) {
-				TileEntityReactorControlRod sourceControlRod = (TileEntityReactorControlRod) tileEntity;
-				RadiationData radData = radiationHelper.radiate(worldObj, fuelContainer, source, sourceControlRod, getFuelHeat(), getReactorHeat(), attachedControlRods.size());
-				// Assimilate results of radiation
-				if(radData != null) {
-					addFuelHeat(radData.getFuelHeatChange(attachedFuelRods.size()));
-					addReactorHeat(radData.getEnvironmentHeatChange(getReactorVolume()));
-					fuelConsumedLastTick += radData.fuelUsage;
+			if (this.currentFuelRod.hasNext()) {
+				// Radiate from that control rod
+				TileEntityReactorFuelRod source  = currentFuelRod.next();
+				TileEntity tileEntity = worldObj.getTileEntity(source.xCoord, getMaximumCoord().y, source.zCoord);
+				if (tileEntity instanceof TileEntityReactorControlRod) {
+					TileEntityReactorControlRod sourceControlRod = (TileEntityReactorControlRod) tileEntity;
+					RadiationData radData = radiationHelper.radiate(worldObj, fuelContainer, source, sourceControlRod, getFuelHeat(), getReactorHeat(), attachedControlRods.size());
+					// Assimilate results of radiation
+					if(radData != null) {
+						addFuelHeat(radData.getFuelHeatChange(attachedFuelRods.size()));
+						addReactorHeat(radData.getEnvironmentHeatChange(getReactorVolume()));
+						fuelConsumedLastTick += radData.fuelUsage;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
i once got a ClassCastException crash caused by casting a TileEntityReactorFuelRod to a TileEntityReactorControlRod. i havent experimented but its pretty obvious it happens if someone places a fuel rod where a control rod is meant to be, and somehow passed the checks saying the block was accepted, because ive placed all sorts of block in those locations by mistake sometimes but it never crashed. 
so checking if the tileentity is a control rod should hopefully fix that rare crash.

the crash report if you want to read: https://pastebin.com/D81r33Fy